### PR TITLE
use site.bookID in anchor links properly

### DIFF
--- a/JekyllHelp/_English.lproj/overview.md
+++ b/JekyllHelp/_English.lproj/overview.md
@@ -13,7 +13,7 @@ This is the Jekyll Apple Help template. This overview has some markdown samples.
 ## Links
 
 - [Normal Link to topic-1, "Do Something"](topic-1.html)
-- [Help anchor-link to the index page anchor, "title-page"](help:anchor=title-page+{{ site.bookid }})
+- [Help anchor-link to the index page anchor, "title-page"](help:anchor=title-page+bookID={{ site.bookid }})
 - [Help openbook-link to Apple's Mac Help](help:openbook=com.apple.machelp)
 - <!-- Note use of + for space. Alternatively use %20 -->
   [Help anchor-link to Safari's keyboard shortcuts](help:anchor=cpsh003+bookID=com.apple.safari.help)

--- a/JekyllHelp/_config.yml
+++ b/JekyllHelp/_config.yml
@@ -4,6 +4,8 @@ apple_help: true  # Flag for conditional markup, if needed.
 # Build settings
 markdown: kramdown
 
+bookid: com.example.myapp.help
+
 # Localization collections for Help topics. Add more languages as needed.
 collections:
   English.lproj:


### PR DESCRIPTION
The `site.bookid` parameter was missing and it seems the anchor link format is `bookID=...`. At least now it works, although I'm not super thrilled about the hardcoded `bookid` value in the config file.
